### PR TITLE
refactor: removed the toggle switches for the unusable twitter and im…

### DIFF
--- a/extension/public/popup.css
+++ b/extension/public/popup.css
@@ -121,14 +121,16 @@ header {
 
 .content .top .sites .toggle-list {
     position: absolute;
-    top: 51px;
+    top: 80px;
     width: 100%;
+    height: 40%;
 
     display:flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: space-evenly;
     align-items: center;
     row-gap: 12px;
+
 }
 
 .content .top .sites .toggle-list .toggle-item {
@@ -140,8 +142,8 @@ header {
 }
 
 .content .top .sites .toggle-list .toggle-item img {
-    width: 36px;
-    height: 36px;
+    width: 48px;
+    height: 48px;
     left: 22px;
     top: 6px;
 }

--- a/extension/public/popup.html
+++ b/extension/public/popup.html
@@ -34,20 +34,6 @@
                             <span class="slider round"></span>
                         </label>
                     </div>
-                    <div class="toggle-item">
-                        <img src="./images/icon-imgur-128.png"/>
-                        <label class="switch">
-                            <input type="checkbox" id="imgurSwitch">
-                            <span class="slider round"></span>
-                        </label>
-                    </div>
-                    <div class="toggle-item">
-                        <img src="./images/icon-twitter-128.png"/>
-                        <label class="switch" >
-                            <input type="checkbox" id="twitterSwitch">
-                            <span class="slider round"></span>
-                        </label>
-                    </div>
                     <button id="addOtherSites">Add other sites</button>
                 </div>
                 <div class="global">

--- a/extension/public/popup.js
+++ b/extension/public/popup.js
@@ -3,16 +3,12 @@
 // UI references
 const toggleList = document.getElementById("toggleList");
 const redditSwitch = document.getElementById("redditSwitch");
-const imgurSwitch = document.getElementById("imgurSwitch");
-const twitterSwitch = document.getElementById("twitterSwitch");
 const addOtherSites = document.getElementById("addOtherSites");
 const globalSwitch = document.getElementById("globalSwitch");
 
 const globalSwitchHandler = () => {
     if(globalSwitch.checked == true) {
         redditSwitch.checked = false;
-        imgurSwitch.checked = false;
-        twitterSwitch.checked = false;
 
         toggleList.style.pointerEvents = "none";
         toggleList.style.opacity = "50%";


### PR DESCRIPTION
…gur sites from the extension ui

## Todo

- [x] remove the Imgur and Twitter toggle switches from the Enabled Sites section

## Motivation

Our extension currently only has an implementation for Reddit, hence, these switches are redundant.

## Summary of changes

- removed corresponding HTML elements from popup.html
- removed corresponding CSS from popup.css
- modified popup.js such that no references were made to the removed elements

## Attached GitHub issue

Closes #27 

### Local Build
- [x] Ran all pre-commit hooks `pre-commit run --all-files`
- [x] Extension has been tested to build correctly `cd extension && yarn && yarn build`
- [x] Extension test suite has been run locally `cd extension && yarn && yarn test`

### GitHub
- [x] Target branch has been set correctly
- [x] PR has been rebased onto target branch
- [x] PR has been assigned an owner
- [x] Author has performed a self-review of the code
- [x] Removed the WIP message from the top of this PR
