### PR TITLE
Add Team 4 to website footer

### DIFF
--- a/website/layouts/default.vue
+++ b/website/layouts/default.vue
@@ -8,7 +8,7 @@
 		<footer class="footer">
 			<div class="content has-text-centered">
 				<p>
-				<strong>Politicry</strong> by <a href="#team">Team 6</a>. The source code is licensed
+				<strong>Politicry</strong> by <a href="#team">Team 4 and Team 6</a>. The source code is licensed
 				<a href="http://opensource.org/licenses/mit-license.php">MIT</a>. The website content
 				is licensed <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY NC SA 4.0</a>.
 				</p>


### PR DESCRIPTION
## Todo
- [x] Update authors in website footer

## Motivation
- This was missing in #53 

## Summary of changes
- Updated `Team 6` --> `Team 4 and Team 6` in footer. 

## Attached GitHub issue
Closes #53
## Checklist

### Documentation
- [x] Updated the readme documents (`README.md` etc.)
- [x] New functions and methods have additional comments added to document their usage

### GitHub
- [x] Target branch has been set correctly
- [x] PR has been rebased onto target branch
- [x] PR has been assigned an owner
- [x] Author has performed a self-review of the code
- [x] Removed the WIP message from the top of this PR

![image](https://user-images.githubusercontent.com/78716153/190625484-4ba6d7d4-fd93-44fc-b9fc-4f8f49076105.png)
