### PR TITLE
Disable Twitter and Imgur toggles

### DIFF
--- a/extension/public/popup.html
+++ b/extension/public/popup.html
@@ -38,14 +38,14 @@
                         <img src="./images/icon-imgur-128.png"/>
                         <label class="switch">
                             <input type="checkbox" id="imgurSwitch">
-                            <span class="slider round"></span>
+                            <span class="slider round" title="Imgur is not yet supported"></span>
                         </label>
                     </div>
                     <div class="toggle-item">
                         <img src="./images/icon-twitter-128.png"/>
                         <label class="switch" >
                             <input type="checkbox" id="twitterSwitch">
-                            <span class="slider round"></span>
+                            <span class="slider round" title="Twitter is not yet supported"></span>
                         </label>
                     </div>
                     <button id="addOtherSites">Add other sites</button>

--- a/extension/public/popup.js
+++ b/extension/public/popup.js
@@ -8,6 +8,10 @@ const twitterSwitch = document.getElementById("twitterSwitch");
 const addOtherSites = document.getElementById("addOtherSites");
 const globalSwitch = document.getElementById("globalSwitch");
 
+// Politicry is not yet available for Imgur and Twitter
+imgurSwitch.disabled = true
+twitterSwitch.disabled = true
+
 const globalSwitchHandler = () => {
     if(globalSwitch.checked == true) {
         redditSwitch.checked = false;


### PR DESCRIPTION
## Todo

- [x] Disable Twitter and Imgur toggles
- [x] Add tooltip to disabled toggles

## Motivation
The Twitter and Imgur post detection has not been implemented (and may not be for a while). 

Disabling them is a better solution than removing them entirely because: 
- Removing them makes the extension UI look less complete. This is important for presentation purposes. 
- There would be whitespace where the Twitter/Imgur toggles are currently. 
- Some of the UI components would not make much sense e.g. the global toggle, "Enabled Sites", "Add Other Sites".

## Summary of changes
- Disable Twitter and Imgur toggles in `popup.js`
- Add tooltip in `popup.html` to disabled toggles

## Attached GitHub issue
Closes #27 

## Checklist

### Documentation
- [x] Updated the readme documents (`README.md` etc.)
- [x] New functions and methods have additional comments added to document their usage

### Local Build
- [x] Extension has been tested to build correctly `cd extension && yarn && yarn build`

### GitHub
- [x] Target branch has been set correctly
- [x] PR has been rebased onto target branch
- [x] PR has been assigned an owner
- [x] Author has performed a self-review of the code
- [x] Removed the WIP message from the top of this PR

### Screenshots
Hovering over the Imgur (and Twitter) toggles will show a tooltip
![image](https://user-images.githubusercontent.com/78716153/190891860-da871072-19bd-4fd4-9884-c7a608281051.png)

The Reddit toggle still works
![image](https://user-images.githubusercontent.com/78716153/190891845-8a5af284-b9e9-4c18-a012-69945f6acb8a.png)

