### PR TITLE
Persistent user config

### DIFF
--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -34,7 +34,8 @@
     },
     "permissions": [
         "activeTab",
-        "scripting"
+        "scripting",
+        "storage"
     ],
     "version": "1.0"
 }

--- a/extension/public/popup.js
+++ b/extension/public/popup.js
@@ -24,10 +24,28 @@ const globalSwitchHandler = () => {
         toggleList.style.pointerEvents = "auto";
         toggleList.style.opacity = "100%";
     }
+
+    chrome.storage.sync.set({ globalToggled: globalSwitch.checked });
 }
 
-globalSwitch.onclick = globalSwitchHandler;
+const redditSwitchHandler = () => {
+    chrome.storage.sync.set({ redditToggled: redditSwitch.checked });
+}
 
+// onchange instead of onclick as the state may change programatically
+globalSwitch.onchange = globalSwitchHandler;
+redditSwitch.onchange = redditSwitchHandler;
+
+// Set initial state of toggles
+chrome.storage.sync.get(['redditToggled'], function(data) {
+    redditSwitch.checked = data.redditToggled;
+    redditSwitchHandler();
+});
+
+chrome.storage.sync.get(['globalToggled'], function(data) {
+    globalSwitch.checked = data.globalToggled;
+    globalSwitchHandler();
+});
 
 /********** Keywords **********/
 


### PR DESCRIPTION
## Todo
- [x] Add `storage` permission in the manifest
- [x] Get and save the boolean value for the Reddit toggle
- [x] Get and save the boolean value for the Global toggle

## Motivation
The state of the extension was previously not saved when the user closed it.

## Summary of changes
- Add `storage` permission in `manifest.json`.
- Save the boolean value of the toggles when it is updated. `onchange` was used instead of `onclick` as the state may also be set programmatically e.g. when using the global toggle, the Reddit toggle will be automatically updated.
- Set the boolean values of the toggles when the extension in opened.
- `chrome.storage.sync` was used instead of ` chrome.storage.local` as the user will probably want to retain this setting on other devices that they are signed into. 
- This states have not been saved for the Imgur/Twitter toggles as they are disabled (Politicry has not been implemented for them yet). 

## Attached GitHub issue
Closes #31 

## Checklist

### Documentation
- [x] New functions and methods have additional comments added to document their usage

### Local Build
- [x] Ran all pre-commit hooks `pre-commit run --all-files`
- [x] Extension has been tested to build correctly `cd extension && yarn && yarn build`

### GitHub
- [x] Target branch has been set correctly
- [x] PR has been rebased onto target branch
- [x] PR has been assigned an owner
- [x] Author has performed a self-review of the code
- [x] Removed the WIP message from the top of this PR
