### PR TITLE
Add editing keyword functionality to the extension

### DIFF
--- a/extension/public/popup.css
+++ b/extension/public/popup.css
@@ -227,6 +227,8 @@ header {
 
     width: 148px;
 
+    font-size: 16px;
+
     display:flex;
     flex-direction: column;
     justify-content: center;
@@ -286,6 +288,47 @@ header {
     background-color: #47a8f8;
 }
 
+.edit-tags {
+    position: absolute;
+    top: 100px;
+    left: 22px;
+
+    width: 148px;
+    height: 160px;
+
+    resize: none;
+    visibility: hidden;
+}
+
+.edit-tags-actions {
+    visibility: hidden;
+}
+
+.tags-action-btn {
+    position: absolute;
+    bottom: 40px;
+
+    width: 60px;
+    height: 24px;
+
+    color: white;
+    font-weight: 200;
+
+    border: none;
+    border-radius: 4px;
+
+    cursor: pointer;
+}
+
+#saveTagsBtn {
+    background-color: #2196F3;
+    left: 32px;
+}
+
+#cancelTagsBtn {
+    background-color: #999999;
+    right: 32px;
+}
 /*------- Bottom: Backend -------*/
 
 .backend {

--- a/extension/public/popup.html
+++ b/extension/public/popup.html
@@ -66,7 +66,12 @@
                 </div>
                 <div class="tag-list" id="tagList">
                 </div>
-                <button class="manage-tag-list-btn" id="manageTagListBtn"">Manage</button>
+                <textarea class="edit-tags" id="editTagsTextArea"></textarea>
+                <button class="manage-tag-list-btn" id="manageTagListBtn">Manage</button>
+                <div class="edit-tags-actions" id="editTagsActions">
+                    <button class="tags-action-btn" id="saveTagsBtn">Save</button>
+                    <button class="tags-action-btn" id="cancelTagsBtn">Cancel</button>
+                </div>
             </div>
         </div>
         <div class="bottom">

--- a/extension/public/popup.js
+++ b/extension/public/popup.js
@@ -49,56 +49,105 @@ chrome.storage.sync.get(['globalToggled'], function(data) {
 
 /********** Keywords **********/
 
-// keywords data
-const allowedWordsData = [
-    "ukraine",
-    "blm",
-    "gas prices"
-];
-
-const blockedWordsData = [
-    "trump",
-    "terrorist",
-    "communism",
-    "racism",
-    "isis",
-    "pizza"
-];
-
 // UI references
 const allowedBtn = document.getElementById("allowedBtn");
 const blockedBtn = document.getElementById("blockedBtn");
 const tagList = document.getElementById("tagList");
 const manageTagListBtn = document.getElementById("manageTagListBtn");
+const editTagsTextArea = document.getElementById("editTagsTextArea");
+const editTagsActions = document.getElementById("editTagsActions");
+const saveBtn = document.getElementById("saveTagsBtn");
+const cancelBtn = document.getElementById("cancelTagsBtn");
 
 // Helper:
 const renderAllowedWords = () => {
-    const max = 4;
-    const numTagItems = allowedWordsData.length > max ? max : allowedWordsData.length;
-    const numMoreResults=  allowedWordsData.length - numTagItems;
+    hideTagsEdit();
 
-    let tagItems = "";
-    const moreResults = numMoreResults > 0 ? `<div class=\"tag-results-item\">${numMoreResults} more</div>` : "";
+    chrome.storage.sync.get(['allowedWords'], function(data) {
+        const allowedWordsData = data.allowedWords;
+        if (allowedWordsData == undefined || allowedWordsData.length == 0) {
+            tagList.innerHTML = "No keywords set!"
+        }
 
-    for (let i=0; i<numTagItems; i++) {
-        tagItems += `<div class=\"tag-item\">${allowedWordsData[i]}</div>`;
-    }
-    tagList.innerHTML = tagItems + moreResults;
+        const max = 4;
+        const numTagItems = allowedWordsData.length > max ? max : allowedWordsData.length;
+        const numMoreResults=  allowedWordsData.length - numTagItems;
+
+        let tagItems = "";
+        const moreResults = numMoreResults > 0 ? `<div class=\"tag-results-item\">${numMoreResults} more</div>` : "";
+
+        for (let i=0; i<numTagItems; i++) {
+            tagItems += `<div class=\"tag-item\">${allowedWordsData[i]}</div>`;
+        }
+
+        tagList.innerHTML = tagItems + moreResults;
+    });
 }
 
 // Helper:
 const renderBlockedWords = () => {
-    const max = 4;
-    const numTagItems = blockedWordsData.length > max ? max : blockedWordsData.length
-    const numMoreResults=  blockedWordsData.length - numTagItems;
+    hideTagsEdit();
+    chrome.storage.sync.get(['blockedWords'], function(data) {
+        const blockedWordsData = data.blockedWords;
+        if (blockedWordsData == undefined || blockedWordsData.length == 0) {
+            tagList.innerHTML = "No keywords set!"
+        }
 
-    let tagItems = "";
-    const moreResults = numMoreResults > 0 ? `<div class=\"tag-results-item\">${numMoreResults} more</div>` : "";
+        const max = 4;
+        const numTagItems = blockedWordsData.length > max ? max : blockedWordsData.length
+        const numMoreResults=  blockedWordsData.length - numTagItems;
 
-    for (let i=0; i<numTagItems; i++) {
-        tagItems += `<div class=\"tag-item\">${blockedWordsData[i]}</div>`;
+        let tagItems = "";
+        const moreResults = numMoreResults > 0 ? `<div class=\"tag-results-item\">${numMoreResults} more</div>` : "";
+
+        for (let i=0; i<numTagItems; i++) {
+            tagItems += `<div class=\"tag-item\">${blockedWordsData[i]}</div>`;
+        }
+
+        tagList.innerHTML = tagItems + moreResults;
+    });
+}
+
+// Helper:
+const renderTagsEdit = () => {
+    manageTagListBtn.style.visibility = 'hidden';
+    editTagsActions.style.visibility = 'visible';
+    editTagsTextArea.style.visibility = 'visible';
+
+    if (manageTagListBtn.innerHTML == "Edit Allowed") {
+        chrome.storage.sync.get(['allowedWords'], function(data) {
+            editTagsTextArea.value = arrayToCsv(data.allowedWords);
+        });
+    } else {
+        chrome.storage.sync.get(['blockedWords'], function(data) {
+            editTagsTextArea.value = arrayToCsv(data.blockedWords);
+        });
     }
-    tagList.innerHTML = tagItems + moreResults;
+}
+
+// Helper:
+const hideTagsEdit = () => {
+    manageTagListBtn.style.visibility = 'visible';
+    editTagsActions.style.visibility = 'hidden';
+    editTagsTextArea.style.visibility = 'hidden';
+}
+
+// Helper:
+// Array --> Comma Separated Values
+// Converts array of strings to a single string where each value is separated by a comma
+const arrayToCsv = (array) => {
+    let csv = ""
+
+    for (const word of array) {
+        csv += word + ",";
+    }
+
+    // Remove last comma
+    if (array.length > 0) {
+        csv = csv.substring(0, csv.length - 1);
+    }
+
+    return csv;
 }
 
 // Method:
@@ -117,8 +166,40 @@ const blockedBtnHandler = () => {
     renderBlockedWords();
 }
 
+// Method:
+const manageTagListBtnHandler = () => {
+    renderTagsEdit();
+}
+
+// Method:
+const saveBtnHandler = () => {
+    // Split the text by commas
+    // If the text is an empty string, return an empty array (rather than an array with an empty string value)
+    const newWordList = editTagsTextArea.value == "" ? [] : editTagsTextArea.value.split(',').map(function (word) {
+        return word.trim();
+    })
+
+    if (manageTagListBtn.innerHTML == "Edit Allowed") {
+        chrome.storage.sync.set({ allowedWords: newWordList });
+        renderAllowedWords();
+    } else {
+        chrome.storage.sync.set({ blockedWords: newWordList });
+        renderBlockedWords();
+    }
+
+    hideTagsEdit();
+}
+
+// Method:
+const cancelBtnHandler = () => {
+    hideTagsEdit();
+}
+
 // assign buttons their respective functions
 allowedBtn.onclick = allowedBtnHandler;
 blockedBtn.onclick = blockedBtnHandler;
+manageTagListBtn.onclick = manageTagListBtnHandler;
+saveBtn.onclick = saveBtnHandler;
+cancelBtn.onclick = cancelBtnHandler;
 
 allowedBtnHandler();


### PR DESCRIPTION
## Todo
- [x] Add text area
- [x] Add Save/Cancel buttons
- [x] Show/hide UI components appropriately
- [x] Convert comma-separated values to chips 
- [x] Convert chips to comma-separated values in the text area
- [x] Update list of allowed and blocked words in Chrome Storage

## Motivation
The Edit Allowed/Edit Blocked button previously did nothing. 

## Summary of changes
- Updated `popup.css` for positioning and styling of new elements 
- Added save/cancel buttons and textarea to `popup.html` 
- Removed hard-coded list of allowed/blocked words from `popup.js`
- `chrome.storage.sync.get` to asynchronously get the list of allowed/blocked words
- `chrome.storage.sync.set` to save/update the list of words
- Show/hide UI components by setting the `visibility` attribute
- At the start, there are no words saved (the values in Chrome Storage are `undefined`). An appropriate message is displayed in the place of the chips. Same if a list of 0 words is saved. 

### Some things to note: 
- The blurring is based on the blocked words is done in `reddit.js`. The blocked words are currently hardcoded, rather than based on the values in Chrome Storage. The fix for this should be done under issue #82.
- The allowed list of words currently has no purpose in the extension. Perhaps the previous group wanted them to override posts that are being blurred due to the list of blocked words. Again, changes to implement that should be done in separate PR/issue. 
- The previous group used absolute positioning in the extension GUI. While this is not ideal, I have followed the conventions they have used to ensure consistency. If the extension GUI becomes hard to modify as we add other UI components to it, the CSS positions may need to be updated. 

## Attached GitHub issue
Closes #71 

## Checklist

<!-- If not applicable to this PR, the item can be checked, crossed out, or removed. -->
### Documentation
- [x] New functions and methods have additional comments added to document their usage

### Local Build
- [x] Extension has been tested to build correctly `cd extension && yarn && yarn build`

### GitHub
- [x] Target branch has been set correctly
- [x] PR has been rebased onto target branch
- [x] PR has been assigned an owner
- [x] Author has performed a self-review of the code
- [x] Removed the WIP message from the top of this PR
