### PR TITLE
Merge action and page_action in extension manifest

### DIFF
--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -1,6 +1,11 @@
 {
   "action": {
-    "default_popup": "popup.html"
+    "default_popup": "popup.html",
+    "default_icon": {
+      "128": "/images/logo-128.png",
+      "16": "/images/logo-16.png",
+      "48": "/images/logo-48.png"
+    }
   },
   "background": {
     "service_worker": "background.js"
@@ -27,13 +32,6 @@
   },
   "manifest_version": 3,
   "name": "Politicry",
-  "page_action": {
-    "default_icon": {
-      "128": "/images/logo-128.png",
-      "16": "/images/logo-16.png",
-      "48": "/images/logo-48.png"
-    }
-  },
   "permissions": ["activeTab", "scripting", "storage"],
   "version": "1.0"
 }


### PR DESCRIPTION
## Todo
- [x] Migrate everything in `page_action` in `manifest.json` into `action` to abide by version 3 rules. 

## Motivation
There was a warning "'page_action' requires manifest version of 2 or lower." when you added the extension to your browser.

## Summary of changes
See Todo

## Attached GitHub issue
Closes #83 

## Checklist

### Local Build

- [x] Ran all pre-commit hooks `pre-commit run --all-files`
- [x] Extension has been tested to build correctly `cd extension && yarn && yarn build`
- [x] Extension test suite has been run locally `cd extension && yarn && yarn test`

### GitHub

- [x] Target branch has been set correctly
- [x] PR has been rebased onto target branch
- [x] PR has been assigned an owner
- [x] Author has performed a self-review of the code
- [x] Removed the WIP message from the top of this PR
