### PR TITLE
read blocked list from chrome storage

### DIFF
--- a/extension/public/popup.html
+++ b/extension/public/popup.html
@@ -93,6 +93,7 @@
         <img src="./images/external-link-128.png" />
       </a>
     </footer>
+    <script src="worker/shared.js" defer></script>
     <script src="popup.js" defer></script>
   </body>
 </html>

--- a/extension/public/popup.js
+++ b/extension/public/popup.js
@@ -86,6 +86,7 @@ const renderAllowedWords = () => {
     const allowedWordsData = data.allowedWords;
     if (allowedWordsData === undefined || allowedWordsData.length === 0) {
       tagList.innerHTML = "No keywords set!";
+      return;
     }
 
     const max = 4;
@@ -111,9 +112,9 @@ const renderAllowedWords = () => {
 const renderBlockedWords = () => {
   hideTagsEdit();
   chrome.storage.sync.get(["blockedWords"], (data) => {
-    const blockedWordsData = data.blockedWords;
+    let blockedWordsData = data.blockedWords;
     if (!blockedWordsData || blockedWordsData.length === 0) {
-      tagList.innerHTML = "No keywords set!";
+      blockedWordsData = window.defaultBlockedWordsList;
     }
 
     const max = 4;
@@ -143,11 +144,13 @@ const renderTagsEdit = () => {
 
   if (manageTagListBtn.innerHTML === "Edit Allowed") {
     chrome.storage.sync.get(["allowedWords"], (data) => {
-      editTagsTextArea.value = arrayToCsv(data.allowedWords);
+      editTagsTextArea.value = arrayToCsv(data.allowedWords || []);
     });
   } else {
     chrome.storage.sync.get(["blockedWords"], (data) => {
-      editTagsTextArea.value = arrayToCsv(data.blockedWords);
+      let list = data.blockedWords;
+      if (!list || !list.length) list = window.defaultBlockedWordsList;
+      editTagsTextArea.value = arrayToCsv(list);
     });
   }
 };

--- a/extension/public/worker/instagram.js
+++ b/extension/public/worker/instagram.js
@@ -39,11 +39,16 @@ function checkImage(img) {
   }
 }
 
-// check every 1 second if a new post has been loaded
-setInterval(() => {
-  // part 1: check the main post visible
-  checkOpenPost();
+window.onceReady = () => {
+  // part 0: quit if instagram is not enabled
+  if (!window.enabled.instagram) return;
 
-  // part 2: check the alt-text of every image
-  document.querySelectorAll("img").forEach(checkImage);
-}, 1000);
+  // check every 1 second if a new post has been loaded
+  setInterval(() => {
+    // part 1: check the main post visible
+    checkOpenPost();
+
+    // part 2: check the alt-text of every image
+    document.querySelectorAll("img").forEach(checkImage);
+  }, 1000);
+};

--- a/extension/public/worker/reddit.js
+++ b/extension/public/worker/reddit.js
@@ -13,6 +13,9 @@ const Reddit = {
 
   // initalize
   initialize() {
+    // quit if reddit is not enabled
+    if (!window.enabled.reddit) return;
+
     this.blurImage();
     this.checkForUpdate();
   },
@@ -33,17 +36,6 @@ const Reddit = {
   // check if any configured keywords are found in a post
   // return true if found
   async filterText(post, callBack) {
-    // temporary filter data
-    // these data must be stored in cookie
-    const blockedWordsData = [
-      "trump",
-      "terrorist",
-      "communism",
-      "racism",
-      "isis",
-      "pizza",
-    ];
-
     const title = this.getDOMTitle(post);
     const description = this.getDOMDescription(post);
     // image varible contain image url then contain result of ocr
@@ -59,19 +51,7 @@ const Reddit = {
       callBack();
     }
 
-    // search if blockedwords are in the title
-    // true if found
-    let isInclude = false;
-    for (const i in blockedWordsData) {
-      if (title.includes(blockedWordsData[i])) {
-        isInclude = true;
-      } else if (image.includes(blockedWordsData[i])) {
-        isInclude = true;
-      } else if (description.includes(blockedWordsData[i])) {
-        isInclude = true;
-      }
-    }
-    return isInclude;
+    return window.matchesBlocklist(title + description + image);
   },
 
   // extract text from image using tesseract
@@ -133,22 +113,18 @@ const Reddit = {
   // retrive the posts iamge link
   getDOMImageLink(_post) {
     const classSelector = "._2_tDEnGMLxpM6uOa2kaDB3";
-    let url = _post.querySelector(classSelector);
-    if (url !== undefined) {
-      url = url.getAttribute("src");
-      // console.log("image url: " + url); // DEBUG
-      return url;
+    const url = _post.querySelector(classSelector);
+    if (url) {
+      return url.getAttribute("src");
     } // image link was empty, hence the post does not contain image
     return "";
   },
 
   getDOMTitle(_post) {
     const classSelector = "._eYtD2XCVieq6emjKBH3m";
-    let title = _post.querySelector(classSelector);
-    if (title !== undefined) {
-      title = title.textContent.toLowerCase();
-      // console.log("post title: " + title); // DEBUG
-      return title;
+    const title = _post.querySelector(classSelector);
+    if (title) {
+      return title.textContent.toLowerCase();
     } // title was empty, returns empty string value
     return "";
   },
@@ -157,7 +133,7 @@ const Reddit = {
   getDOMDescription(_post) {
     const descriptionSelector = "._292iotee39Lmt0MkQZ2hPV";
     let description = _post.querySelector(descriptionSelector);
-    if (description !== undefined) {
+    if (description) {
       description = description.textContent.toLowerCase();
       // console.log("post description: " + description); // DEBUG
       return description;
@@ -166,4 +142,4 @@ const Reddit = {
   },
 };
 
-Reddit.initialize();
+window.onceReady = () => Reddit.initialize();

--- a/extension/public/worker/shared.js
+++ b/extension/public/worker/shared.js
@@ -1,6 +1,9 @@
-// this file is shared amongst all workers
+// this file is shared amongst all workers AND the popup page
 
-const blockedWordsData = [
+/// <reference types="chrome" />
+/* global chrome */
+
+window.defaultBlockedWordsList = [
   "trump",
   "terrorist",
   "communism",
@@ -9,7 +12,27 @@ const blockedWordsData = [
   "pizza",
 ];
 
+let blockedList = window.defaultBlockedWordsList;
+
+chrome.storage.sync.get(
+  ["blockedWords", "redditToggled", "instagramToggled", "twitterToggled"],
+  (data) => {
+    window.enabled = {
+      reddit: data.redditToggled,
+      instagram: data.instagramToggled,
+      twitter: data.twitterToggled,
+    };
+
+    // replace the blocklist with the list from chrome storage
+    if (data.blockedWords && data.blockedWords.length) {
+      blockedList = data.blockedWords;
+    }
+
+    // lastly, call the "onceReady" function if it exists
+    window.onceReady?.();
+  },
+);
+
 /* returns true if the supplied text matches any word in the blocked list */
-window.matchesBlocklist = (text) => {
-  return blockedWordsData.some((word) => text.includes(word));
-};
+window.matchesBlocklist = (text) =>
+  blockedList.some((word) => text.toLowerCase().includes(word.toLowerCase()));

--- a/extension/public/worker/twitter.js
+++ b/extension/public/worker/twitter.js
@@ -5,9 +5,14 @@ function checkTweet(el) {
   }
 }
 
-// check every 1 second if a new post has been loaded
-setInterval(() => {
-  // check every visible tweet, which can be identified since it's a
-  // div with an attribute called lang="en". Politicry only supports English (for now)
-  document.querySelectorAll('div[lang="en"]').forEach(checkTweet);
-}, 1000);
+window.onceReady = () => {
+  // quit if twitter is not enabled
+  if (!window.enabled.twitter) return;
+
+  // check every 1 second if a new post has been loaded
+  setInterval(() => {
+    // check every visible tweet, which can be identified since it's a
+    // div with an attribute called lang="en". Politicry only supports English (for now)
+    document.querySelectorAll('div[lang="en"]').forEach(checkTweet);
+  }, 1000);
+};


### PR DESCRIPTION
## Todo

- [x] make reddit respect the on/off switch and use the user's chosen blocked list ([link to test](https://www.reddit.com/search/?q=pizza))
- [x] make instagram respect the on/off switch and use the user's chosen blocked list ([link to test](https://instagr.am/pizza))
- [x] make twitter respect the on/off switch and use the user's chosen blocked list ([link to test](https://twitter.com/dominos))
- [x] use the default list of banned words if no words are configured by the user

## Implementation

The popup already saves user settings into chrome's storage API, which was added in #67 using `chrome.storage.sync.set`. This PR updates the extension workers to use `chrome.storage.sync.get` to read those preferences and adhere to them. 

Since loading data from chrome's storage takes time, the blurring process is delayed until the user preferences are loaded. This was achieved by introducing `window.onceReady`, which is called by `shared.js`. The files for each social media platform can implement `window.onceReady` differently.

## Test plan

- test turning the switch on/off and then visiting each social media website (or reloading the page)
- test configuring a custom list of banned words and see if this takes effect

## Motivation

The user's settings weren't being respected, which is confusing and a bug. We want to fix all remaining bugs. 

## Attached GitHub issue

Closes #82


### Documentation

- [x] ~~Updated the readme documents (`README.md` etc.)~~
- [x] New functions and methods have additional comments added to document their usage

### Local Build

- [x] Ran all pre-commit hooks `pre-commit run --all-files`
- [x] Extension has been tested to build correctly `cd extension && yarn && yarn build`
- [x] Backend has been tested to build correctly `cd backend && docker-compose build`
- [x] Extension test suite has been run locally `cd extension && yarn && yarn test`
- [x] Backend test suite has been run locally `cd backend && python3 -m unittest`

### GitHub

- [x] Target branch has been set correctly
- [x] PR has been rebased onto target branch
- [x] PR has been assigned an owner
- [x] Author has performed a self-review of the code
- [x] Removed the WIP message from the top of this PR
