### PR TITLE
Make overflowed tag text ellipsis

### DIFF
--- a/extension/public/popup.css
+++ b/extension/public/popup.css
@@ -233,7 +233,6 @@ header {
   padding: 0 12px 0 12px;
 
   height: 24px;
-  max-width: 124px;
 
   text-align: center;
   color: white;
@@ -242,7 +241,6 @@ header {
 
   border-radius: 12px;
   background-color: #c54ccf;
-
 }
 
 .keywords .tag-list .tag-results-item {
@@ -262,8 +260,8 @@ header {
 }
 
 /* Tag Item's Text */
-.keywords .tag-list .tag-item .tag-text{
-    max-width: 112px;
+.keywords .tag-list .tag-text{
+    max-width: 124px;
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;

--- a/extension/public/popup.css
+++ b/extension/public/popup.css
@@ -233,7 +233,7 @@ header {
   padding: 0 12px 0 12px;
 
   height: 24px;
-  max-width: 148px;
+  max-width: 124px;
 
   text-align: center;
   color: white;
@@ -249,7 +249,7 @@ header {
   padding: 0 12px 0 12px;
 
   height: 20px;
-  max-width: 148px;
+  max-width: 124px;
 
   text-align: center;
   color: #c54ccf;
@@ -262,8 +262,8 @@ header {
 }
 
 /* Tag Item's Text */
-.keywords .tag-list .tag-item .tagText{
-    max-width: 148px;
+.keywords .tag-list .tag-item .tag-text{
+    max-width: 112px;
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;

--- a/extension/public/popup.css
+++ b/extension/public/popup.css
@@ -233,6 +233,7 @@ header {
   padding: 0 12px 0 12px;
 
   height: 24px;
+  max-width: 148px;
 
   text-align: center;
   color: white;
@@ -241,12 +242,14 @@ header {
 
   border-radius: 12px;
   background-color: #c54ccf;
+
 }
 
 .keywords .tag-list .tag-results-item {
   padding: 0 12px 0 12px;
 
   height: 20px;
+  max-width: 148px;
 
   text-align: center;
   color: #c54ccf;
@@ -256,6 +259,15 @@ header {
   border-radius: 12px;
   border: 2px solid #c54ccf;
   background-color: rgba(255, 255, 255, 0);
+}
+
+/* Tag Item's Text */
+.keywords .tag-list .tag-item .tagText{
+    max-width: 148px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    display: inline-block;
 }
 
 .keywords .manage-tag-list-btn {

--- a/extension/public/popup.css
+++ b/extension/public/popup.css
@@ -241,13 +241,18 @@ header {
 
   border-radius: 12px;
   background-color: #c54ccf;
+
+  max-width: 124px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  display: inline-block;
 }
 
 .keywords .tag-list .tag-results-item {
   padding: 0 12px 0 12px;
 
   height: 20px;
-  max-width: 124px;
 
   text-align: center;
   color: #c54ccf;
@@ -257,15 +262,12 @@ header {
   border-radius: 12px;
   border: 2px solid #c54ccf;
   background-color: rgba(255, 255, 255, 0);
-}
 
-/* Tag Item's Text */
-.keywords .tag-list .tag-text{
-    max-width: 124px;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
-    display: inline-block;
+  max-width: 124px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  display: inline-block;
 }
 
 .keywords .manage-tag-list-btn {

--- a/extension/public/popup.js
+++ b/extension/public/popup.js
@@ -101,11 +101,10 @@ const renderAllowedWords = () => {
         : "";
 
     for (let i = 0; i < numTagItems; i++) {
-      tagItems += `<div class="tag-item" ><span class="tag-item tag-text">${allowedWordsData[i]}</span></div>`;
+      tagItems += `<div class="tag-item tag-text">${allowedWordsData[i]}</div>`;
     }
 
-    tagList.innerHTML = tagItems + moreResults;
-    
+    tagList.innerHTML = tagItems + moreResults;    
   });
 };
 

--- a/extension/public/popup.js
+++ b/extension/public/popup.js
@@ -101,10 +101,11 @@ const renderAllowedWords = () => {
         : "";
 
     for (let i = 0; i < numTagItems; i++) {
-      tagItems += `<div class="tag-item">${allowedWordsData[i]}</div>`;
+      tagItems += `<div class="tag-item" ><span class="tagText">${allowedWordsData[i]}</span></div>`;
     }
 
     tagList.innerHTML = tagItems + moreResults;
+    
   });
 };
 

--- a/extension/public/popup.js
+++ b/extension/public/popup.js
@@ -101,7 +101,7 @@ const renderAllowedWords = () => {
         : "";
 
     for (let i = 0; i < numTagItems; i++) {
-      tagItems += `<div class="tag-item" ><span class="tagText">${allowedWordsData[i]}</span></div>`;
+      tagItems += `<div class="tag-item" ><span class="tag-item tag-text">${allowedWordsData[i]}</span></div>`;
     }
 
     tagList.innerHTML = tagItems + moreResults;

--- a/extension/public/popup.js
+++ b/extension/public/popup.js
@@ -101,7 +101,7 @@ const renderAllowedWords = () => {
         : "";
 
     for (let i = 0; i < numTagItems; i++) {
-      tagItems += `<div class="tag-item tag-text">${allowedWordsData[i]}</div>`;
+      tagItems += `<div class="tag-item">${allowedWordsData[i]}</div>`;
     }
 
     tagList.innerHTML = tagItems + moreResults;    

--- a/extension/public/popup.js
+++ b/extension/public/popup.js
@@ -104,7 +104,7 @@ const renderAllowedWords = () => {
       tagItems += `<div class="tag-item">${allowedWordsData[i]}</div>`;
     }
 
-    tagList.innerHTML = tagItems + moreResults;    
+    tagList.innerHTML = tagItems + moreResults;
   });
 };
 


### PR DESCRIPTION
## Todo

- [x] Fix tag item text overflow 

## Motivation

Saving a very long keyword extends past the extension UI boundaries. Should truncate and add a ... ellipsis to the keyword when displaying the tag text.

## Attached GitHub issue

Closes #85 

## Implementation
Only the CSS properties in `popup.css` were changed. Both `tag-item` and `.tag-results-item` needed changing as they both have the overflow UI bug. `tag-item` configures the CSS for most of the purple keyword chips. `.tag-results-item` configures the CSS for the chip that is used when there are too many keywords set e.g. "2 more". 

## Screenshot
<img width="404" alt="截屏2022-09-28 下午12 57 21" src="https://user-images.githubusercontent.com/37644658/192657984-b4a2eda7-a882-4994-a3b1-6784fd621c17.png">


## Checklist

<!-- If not applicable to this PR, the item can be checked, crossed out, or removed. -->

### Documentation

- [x] Updated the readme documents (`README.md` etc.)
- [x] New functions and methods have additional comments added to document their usage

### Local Build

- [x] Ran all pre-commit hooks `pre-commit run --all-files`
- [x] Extension has been tested to build correctly `cd extension && yarn && yarn build`
- [x] Backend has been tested to build correctly `cd backend && docker-compose build`
- [x] Extension test suite has been run locally `cd extension && yarn && yarn test`
- [x] Backend test suite has been run locally `cd backend && python3 -m unittest`

### GitHub

- [x] Target branch has been set correctly
- [x] PR has been rebased onto target branch
- [x] PR has been assigned an owner
- [x] Author has performed a self-review of the code
- [x] Removed the WIP message from the top of this PR
