### PR TITLE
Fix deleting blocked words reset to default list

### DIFF
--- a/extension/public/popup.js
+++ b/extension/public/popup.js
@@ -113,8 +113,11 @@ const renderBlockedWords = () => {
   hideTagsEdit();
   chrome.storage.sync.get(["blockedWords"], (data) => {
     let blockedWordsData = data.blockedWords;
-    if (!blockedWordsData || blockedWordsData.length === 0) {
+    if (!blockedWordsData) {
       blockedWordsData = window.defaultBlockedWordsList;
+    } else if (blockedWordsData.length === 0) {
+      tagList.innerHTML = "No keywords set!";
+      return;
     }
 
     const max = 4;
@@ -149,7 +152,7 @@ const renderTagsEdit = () => {
   } else {
     chrome.storage.sync.get(["blockedWords"], (data) => {
       let list = data.blockedWords;
-      if (!list || !list.length) list = window.defaultBlockedWordsList;
+      if (!list) list = window.defaultBlockedWordsList;
       editTagsTextArea.value = arrayToCsv(list);
     });
   }


### PR DESCRIPTION
## Todo

- [x] Display "No keywords set!" message when blocked words list is empty
- [x] Remove logic that resets the words list to the default list when the words list is empty

## Motivation
Users might not want to clear their list of blocked words. 
Users may think it's a bug if they clear it and the unwanted default list shows up. 

## Summary of changes
- Changes were made to `popup.js`. 
- The default blocked words list is only used when the `blockedWords` value returned from Chrome Storage is undefined i.e. it has not been set by the user. 
- Set the `innerHtml` of the UI component containing the list of tags to display the "No keywords set!" message (similar to how it is done for the allowed list of words).  

It is now possible to have no blocked keywords set. 
![image](https://user-images.githubusercontent.com/78716153/192913249-269dffc5-ae60-403a-8319-78d5ca3003b7.png)


## Attached GitHub issue
Closes #89 

## Checklist

### Local Build
- [x] Extension has been tested to build correctly `cd extension && yarn && yarn build`

### GitHub
- [x] Target branch has been set correctly
- [x] PR has been rebased onto target branch
- [x] PR has been assigned an owner
- [x] Author has performed a self-review of the code
- [x] Removed the WIP message from the top of this PR
