### PR TITLE
Fix link for logo

### DIFF
--- a/extension/public/popup.html
+++ b/extension/public/popup.html
@@ -17,7 +17,7 @@
     <header>
       <div class="logo">
         <a
-          href="https://github.com/se310-t6/politicry"
+          href="https://politicry.com/"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
## Todo

- [x] Change the redirect link for the logo from https://github.com/se310-t6/politicry to https://politicry.com/

## Motivation

Logo redirected to the incorrect website

## Attached GitHub issue

Closes #92  

## Checklist

<!-- If not applicable to this PR, the item can be checked, crossed out, or removed. -->

### Local Build
- [x] Extension has been tested to build correctly `cd extension && yarn && yarn build`

### GitHub
- [x] Target branch has been set correctly
- [x] PR has been rebased onto target branch
- [x] PR has been assigned an owner
- [x] Author has performed a self-review of the code
- [x] Removed the WIP message from the top of this PR
