### PR TITLE
Refactor popup css positioning

### DIFF
--- a/extension/cypress/e2e/popup.cy.js
+++ b/extension/cypress/e2e/popup.cy.js
@@ -21,4 +21,33 @@ describe("extension popup", () => {
     cy.get("#redditSwitch").should("be.checked");
     cy.get("#instagramSwitch").should("not.be.checked");
   });
+
+  it("displays/hides UI components at the start", () => {
+    cy.get("#tagList").should("have.css", "display", "flex");
+    cy.get("#editTagsTextArea").should("have.css", "display", "none");
+
+    cy.get("#manageTagListBtn").should("have.css", "display", "flex");
+    cy.get("#editTagsActions").should("have.css", "display", "none");
+  });
+
+  it("displays/hides UI components when in edit mode", () => {
+    cy.get("#manageTagListBtn").click();
+
+    cy.get("#tagList").should("have.css", "display", "none");
+    cy.get("#editTagsTextArea").should("have.css", "display", "flex");
+
+    cy.get("#editTagsActions").should("have.css", "display", "flex");
+    cy.get("#manageTagListBtn").should("have.css", "display", "none");
+  });
+
+  it("displays/hides UI components when exiting edit mode", () => {
+    cy.get("#manageTagListBtn").click();
+    cy.get("#cancelTagsBtn").click();
+
+    cy.get("#tagList").should("have.css", "display", "flex");
+    cy.get("#editTagsTextArea").should("have.css", "display", "none");
+
+    cy.get("#manageTagListBtn").should("have.css", "display", "flex");
+    cy.get("#editTagsActions").should("have.css", "display", "none");
+  });
 });

--- a/extension/public/popup.css
+++ b/extension/public/popup.css
@@ -5,14 +5,7 @@
 
 body {
   width: 400px;
-  height: 514px;
   outline: 1px solid black;
-
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: center;
-
   font-family: "Anek Malayalam", sans-serif;
 }
 
@@ -23,31 +16,19 @@ header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0 5% 0 5%;
+  padding: 0 16px;
 
   min-height: 80px;
   color: white;
-  width: 90%;
   box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.25);
 }
 
-.logo {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  cursor: pointer;
-}
-
 .logo a {
-  display: flex;
-  justify-content: center;
-  align-items: center;
   cursor: pointer;
 }
 
 .logo a img {
   height: 36px;
-  width: 134px;
 }
 
 .version {
@@ -70,77 +51,58 @@ header {
 
 .content {
   display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: center;
-  width: 100%;
-  height: 100%;
+  column-gap: 10px;
+  padding: 10px;
+  min-height: 300px;
+
   background-color: rgba(0, 0, 0, 0.1);
 }
 
-.content .top {
-  width: 100%;
-  height: 350px;
-}
-
-/*------- Top: Enabled Sites -------*/
-
-.sites {
-  position: absolute;
-  width: 178px;
-  height: 335px;
-  left: 10px;
-  top: 90px;
+.sites, .keywords {
+  width: 50%;
+  display: flex;
+  flex-direction: column;
 
   background: #ffffff;
   box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.25);
 }
 
-.top div h3 {
-  position: absolute;
-  height: 19px;
-  left: 16px;
-  top: 16px;
-
-  font-style: normal;
-  font-weight: 00;
+h3 {
   font-size: 20px;
-  line-height: 19px;
-
-  display: flex;
-  align-items: center;
-
-  color: #000000;
 }
 
-.content .top .sites .toggle-list {
-  position: absolute;
-  top: 51px;
-  width: 100%;
+.sites-content, .keywords-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex-grow: 1;
+  padding: 16px 8px;
+}
 
+/*------- Top: Enabled Sites -------*/
+
+.sites .toggle-list {
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  flex-grow: 1;
   row-gap: 12px;
 }
 
-.content .top .sites .toggle-list .toggle-item {
+.sites .toggle-list .toggle-item {
   display: flex;
   justify-content: center;
   align-items: center;
   column-gap: 10px;
-  height: 40px;
 }
 
-.content .top .sites .toggle-list .toggle-item img {
+.sites .toggle-list .toggle-item img {
   width: 36px;
   height: 36px;
-  left: 22px;
-  top: 6px;
 }
 
-.content .top .sites button {
+.sites button {
   margin-top: 10px;
   text-decoration: underline;
   border: 0;
@@ -153,17 +115,11 @@ header {
   transition: 0.2s ease;
 }
 
-.content .top .sites button:hover {
+.sites button:hover {
   color: #d9381e;
 }
 
 .sites .global {
-  position: absolute;
-  width: 178px;
-  height: 68px;
-  left: 0px;
-  bottom: 0px;
-
   background: rgba(0, 0, 0, 0.8);
   box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.25);
   color: white;
@@ -172,6 +128,7 @@ header {
   justify-content: center;
   align-items: center;
   column-gap: 12px;
+  padding: 16px 0px;
 }
 
 .sites .global img {
@@ -180,61 +137,40 @@ header {
 
 /*------- Top: Keywords -------*/
 
-.keywords {
-  position: absolute;
-  width: 192px;
-  height: 335px;
-  left: 198px;
-  top: 90px;
-
-  background: #ffffff;
-  box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.25);
-}
-
 .keywords .btn-container {
-  position: absolute;
-  top: 51px;
-  left: 22px;
-
   display: flex;
   justify-content: center;
   align-items: center;
-
-  background-color: #0f8e00;
-  width: 148px;
-  height: 30px;
+  width: 100%;
+  margin-top: 16px;
 }
 
 .keywords .btn-container button {
   width: 50%;
-  height: 100%;
   background-color: #999999;
   border: none;
   color: white;
+  padding: 8px;
+}
+
+.keywords .tags {
+  min-height: 175px;
+  height: 100%;
+  margin: 8px 0px;
 }
 
 .keywords .tag-list {
-  position: absolute;
-  top: 100px;
-  left: 22px;
-
-  width: 148px;
-
-  font-size: 16px;
-
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
+
+  font-size: 16px;
   row-gap: 7px;
+  margin-top: 16px;
 }
 
 .keywords .tag-list .tag-item {
   padding: 0 12px 0 12px;
-
-  height: 24px;
-
-  text-align: center;
   color: white;
   font-weight: 500;
   font-size: 16px;
@@ -242,7 +178,7 @@ header {
   border-radius: 12px;
   background-color: #c54ccf;
 
-  max-width: 124px;
+  max-width: 120px;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -252,9 +188,6 @@ header {
 .keywords .tag-list .tag-results-item {
   padding: 0 12px 0 12px;
 
-  height: 20px;
-
-  text-align: center;
   color: #c54ccf;
   font-weight: 500;
   font-size: 16px;
@@ -263,7 +196,7 @@ header {
   border: 2px solid #c54ccf;
   background-color: rgba(255, 255, 255, 0);
 
-  max-width: 124px;
+  max-width: 120px;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -271,19 +204,13 @@ header {
 }
 
 .keywords .manage-tag-list-btn {
-  position: absolute;
-  bottom: 20px;
-  left: 26px;
-
-  width: 140px;
-  height: 40px;
-
   color: white;
   font-weight: 600;
 
   background-color: #2196f3;
   border: none;
   border-radius: 10px;
+  padding: 8px;
 
   cursor: pointer;
 }
@@ -293,45 +220,33 @@ header {
 }
 
 .edit-tags {
-  position: absolute;
-  top: 100px;
-  left: 22px;
-
-  width: 148px;
-  height: 160px;
-
   resize: none;
-  visibility: hidden;
+  display: none;
+  height: 100%;
 }
 
 .edit-tags-actions {
-  visibility: hidden;
+  display: none;
+  column-gap: 8px;
 }
 
 .tags-action-btn {
-  position: absolute;
-  bottom: 40px;
-
-  width: 60px;
-  height: 24px;
-
   color: white;
-  font-weight: 200;
+  font-weight: 600;
 
   border: none;
-  border-radius: 4px;
+  border-radius: 10px;
+  padding: 8px;
 
   cursor: pointer;
 }
 
 #saveTagsBtn {
   background-color: #2196f3;
-  left: 32px;
 }
 
 #cancelTagsBtn {
   background-color: #999999;
-  right: 32px;
 }
 /*------- Footer -------*/
 
@@ -341,7 +256,6 @@ footer {
   justify-content: center;
   align-items: center;
 
-  width: 100%;
   min-height: 80px;
   box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.25);
 }

--- a/extension/public/popup.html
+++ b/extension/public/popup.html
@@ -40,8 +40,8 @@
       </div>
     </header>
     <div class="content">
-      <div class="top">
-        <div class="sites">
+      <div class="sites">
+        <div class="sites-content">
           <h3>Enabled Sites</h3>
           <div class="toggle-list" id="toggleList">
             <div class="toggle-item">
@@ -74,22 +74,26 @@
               <button id="addOtherSites">Add other sites</button>
             </form>
           </div>
-          <div class="global">
-            <img alt="Globe icon" src="./images/icon-global-128.png" />
-            <label class="switch">
-              <input type="checkbox" id="globalSwitch" />
-              <span class="slider round"></span>
-            </label>
-          </div>
         </div>
-        <div class="keywords">
+        <div class="global">
+          <img alt="Globe icon" src="./images/icon-global-128.png" />
+          <label class="switch">
+            <input type="checkbox" id="globalSwitch" />
+            <span class="slider round"></span>
+          </label>
+        </div>
+      </div>
+      <div class="keywords">
+        <div class="keywords-content">
           <h3>Keywords</h3>
           <div class="btn-container">
             <button id="allowedBtn">Allowed</button>
             <button id="blockedBtn">Blocked</button>
           </div>
-          <div class="tag-list" id="tagList"></div>
-          <textarea class="edit-tags" id="editTagsTextArea"></textarea>
+          <div class="tags">
+            <div class="tag-list" id="tagList"></div>
+            <textarea class="edit-tags" id="editTagsTextArea"></textarea>
+          </div>
           <button class="manage-tag-list-btn" id="manageTagListBtn">
             Manage
           </button>

--- a/extension/public/popup.js
+++ b/extension/public/popup.js
@@ -68,9 +68,10 @@ const cancelBtn = document.getElementById("cancelTagsBtn");
 
 // Helper:
 const hideTagsEdit = () => {
-  manageTagListBtn.style.visibility = "visible";
-  editTagsActions.style.visibility = "hidden";
-  editTagsTextArea.style.visibility = "hidden";
+  manageTagListBtn.style.display = "flex";
+  editTagsActions.style.display = "none";
+  editTagsTextArea.style.display = "none";
+  tagList.style.display = "flex";
 };
 
 // Helper:
@@ -141,9 +142,10 @@ const renderBlockedWords = () => {
 
 // Helper:
 const renderTagsEdit = () => {
-  manageTagListBtn.style.visibility = "hidden";
-  editTagsActions.style.visibility = "visible";
-  editTagsTextArea.style.visibility = "visible";
+  manageTagListBtn.style.display = "none";
+  editTagsActions.style.display = "flex";
+  editTagsTextArea.style.display = "flex";
+  tagList.style.display = "none";
 
   if (manageTagListBtn.innerHTML === "Edit Allowed") {
     chrome.storage.sync.get(["allowedWords"], (data) => {


### PR DESCRIPTION
## Todo
- [x] Refactor instances of absolute positioning in the popup layout
- [x] Refactor instances of hard-coded width/height values 
- [x] Remove conflicting or redundant CSS layout properties
- [x] Add back the correct padding/margin/spacing configurations
- [x] Update `popup.html` and `popup.js` as needed
- [x] Add tests to confirm the refactor from `visibility` to `display` shows/hides elements as expected. 

## Motivation
Many components in the extension UI previously used absolute positioning (and fixed width/height). This means additions to the UI in the future will be difficult and more manual. I imagine one would need to use a "trial-and-error" approach on the pixel positioning of the new component.

## Summary of changes
- Flex positioning was used instead of absolute positioning.
- Some class properties were added/removed hence `popup.html` needed to be changed (more below). 
- There were many CSS layout properties that were or became redundant and these were deleted. This is why more lines are deleted than added in the PR. 
- `content` has a `min-height` as the extension would look short/crammed if there weren't many social media platforms in the toggle list. 
- The `sites`/`keywords` and `sites-content` and `keywords-content` classes have been grouped and configured together in the CSS since they essentially have the same styling. 
- The `top` class has been removed since this is redundant. 
- The content for each keyword/site panel is wrapped in the new classes `sites-content` and `keywords-content` to allow for better layout control. The extra navy blue global section is part of the `sites` class but not the `sites-content` class and so, the padding does not apply. 
- Previously, showing/hiding components set the `visibility` CSS property. This worked because the UI components overlapped each other in the layout due to their absolute positioning. This was changed to `display` (`flex` or `none`) so the UI components don't take up space/jiggle the layout when they are hidden. As a result, changes to `popup.js` were made. 
- Additionally, a reference to the list of tags (`tag-list`) was added to `popup.js` to control the show/hide logic of it. Previously, it just was covered by the `textArea`. 
- The styling for the Save/Cancel buttons needed to match the Edit Allowed/Blocked button to avoid the layout resizing whenever toggling between the edit and view modes for the keywords. 
- Slight margin/padding and alignment fixes (see screenshots below).

## Before & After Screenshots 
| Before Refactoring | After Refactoring |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/78716153/193731100-fa39bf94-5240-4c82-b97c-b8aaabd76000.png) | ![image](https://user-images.githubusercontent.com/78716153/193731118-1dab450d-c41a-4e81-a551-60e214ffb006.png) |
| ![image](https://user-images.githubusercontent.com/78716153/193732159-08604ff8-8685-4a78-b216-71e00587e290.png) | ![image](https://user-images.githubusercontent.com/78716153/193732195-4cc5074c-5d7c-4fd7-b341-1e518b1afb6e.png) |

## Responsiveness Testing Screenshots 
| Before Refactoring | After Refactoring |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/78716153/193732317-29b6ff17-2683-40f6-b47c-938cfb5c6497.png) | ![image](https://user-images.githubusercontent.com/78716153/193732348-d54b89f4-4a57-4161-aaeb-72ce480d4663.png) | 
| ![image](https://user-images.githubusercontent.com/78716153/193732411-3209b6ec-0882-41d4-b920-9e2a7084472c.png) | ![image](https://user-images.githubusercontent.com/78716153/193732443-122bea96-81fe-4b67-82f5-c8dfcd855f5f.png) | 

## Attached GitHub issue
Closes #96 

## Checklist
### Documentation

### Local Build
- [x] Extension has been tested to build correctly `cd extension && yarn && yarn build`
- [x] Extension test suite has been run locally `cd extension && yarn && yarn test`

### GitHub
- [x] Target branch has been set correctly
- [x] PR has been rebased onto target branch
- [x] PR has been assigned an owner
- [x] Author has performed a self-review of the code
- [x] Removed the WIP message from the top of this PR
