### PR TITLE
Add tooltips

### DIFF
--- a/extension/cypress/e2e/popup.cy.js
+++ b/extension/cypress/e2e/popup.cy.js
@@ -17,10 +17,22 @@ describe("extension popup", () => {
     });
   });
 
+  // Checbox tests
+
   it("enables the correct checkboxes", () => {
     cy.get("#redditSwitch").should("be.checked");
     cy.get("#instagramSwitch").should("not.be.checked");
   });
+
+  // Tooltip tests
+  
+  it("hides tooltips by default", () => {
+    cy.get(".tooltip").each(($tooltip) => {
+      cy.get($tooltip).should("have.css", "visibility", "hidden");
+    });
+  });
+
+  // Normal vs edit mode tests
 
   it("displays/hides UI components at the start", () => {
     cy.get("#tagList").should("have.css", "display", "flex");

--- a/extension/public/popup.css
+++ b/extension/public/popup.css
@@ -337,3 +337,20 @@ input:checked + .slider:before {
 .slider.round:before {
   border-radius: 50%;
 }
+
+/* Tooltips */
+.tooltip { 
+  visibility: hidden; 
+  position: absolute;
+  z-index: 1;
+  
+  background-color: #000;
+  color: #fff;
+  padding: 4px;
+  border-radius: 6px;
+  font-size: 14px;
+}
+
+.tooltip-element:hover .tooltip {
+  visibility: visible;
+}

--- a/extension/public/popup.css
+++ b/extension/public/popup.css
@@ -351,6 +351,10 @@ input:checked + .slider:before {
   font-size: 14px;
 }
 
+.tooltip-element {
+  cursor: help;
+}
+
 .tooltip-element:hover .tooltip {
   visibility: visible;
 }

--- a/extension/public/popup.html
+++ b/extension/public/popup.html
@@ -45,21 +45,30 @@
           <h3>Enabled Sites</h3>
           <div class="toggle-list" id="toggleList">
             <div class="toggle-item">
-              <img alt="Reddit logo" src="./images/icon-reddit-128.png" />
+              <div class="tooltip-element">
+                <img alt="Reddit logo" src="./images/icon-reddit-128.png" />
+                <span class="tooltip">Reddit</span>
+              </div>
               <label class="switch">
                 <input type="checkbox" id="redditSwitch" />
                 <span class="slider round"></span>
               </label>
             </div>
             <div class="toggle-item">
-              <img alt="Instagram logo" src="./images/icon-instagram-128.png" />
+              <div class="tooltip-element">
+                <img alt="Instagram logo" src="./images/icon-instagram-128.png" />
+                <span class="tooltip">Instagram</span>
+              </div>
               <label class="switch">
                 <input type="checkbox" id="instagramSwitch" />
                 <span class="slider round"></span>
               </label>
             </div>
             <div class="toggle-item">
-              <img alt="Twitter logo" src="./images/icon-twitter-128.png" />
+              <div class="tooltip-element">
+                <img alt="Twitter logo" src="./images/icon-twitter-128.png" />
+                <span class="tooltip">Twitter</span>
+              </div>
               <label class="switch">
                 <input type="checkbox" id="twitterSwitch" />
                 <span class="slider round"></span>
@@ -77,10 +86,13 @@
         </div>
         <div class="global">
           <img alt="Globe icon" src="./images/icon-global-128.png" />
-          <label class="switch">
-            <input type="checkbox" id="globalSwitch" />
-            <span class="slider round"></span>
-          </label>
+          <div class="tooltip-element">
+            <label class="switch">
+              <input type="checkbox" id="globalSwitch" />
+              <span class="slider round"></span>
+            </label>
+            <span class="tooltip">Disable everywhere</span>
+          </div>
         </div>
       </div>
       <div class="keywords">


### PR DESCRIPTION
## Todo
- [x] Add tooltip CSS
- [x] Add tooltips to the global toggle
- [x] Add tooltips to the platform icons
- [x] (Optional) Add tests to check that the tooltips don't show when the extension is first opened

## Motivation
Some platform icons may be unfamiliar to users. The purpose of the global toggle is not obvious. 

## Summary of changes
- The CSS controls whether the tooltip is shown/hidden using the `visibility` property and `:hover` selector. 
- The `tooltip-element` class defines which elements are hoverable. The tooltip span must be nested inside this. The `tooltip-element` could not be directly added to the `<img .. />` tag as this does not work. 

## Attached GitHub issue
Closes #101 

## Checklist

### Documentation

- [x] New functions and methods have additional comments added to document their usage

### Local Build

- [x] Ran all pre-commit hooks `pre-commit run --all-files`
- [x] Extension has been tested to build correctly `cd extension && yarn && yarn build`
- [x] Backend has been tested to build correctly `cd backend && docker-compose build`
- [x] Extension test suite has been run locally `cd extension && yarn && yarn test`
- [x] Backend test suite has been run locally `cd backend && python3 -m unittest`

### GitHub

- [x] Target branch has been set correctly
- [x] PR has been rebased onto target branch
- [x] PR has been assigned an owner
- [x] Author has performed a self-review of the code
- [x] Removed the WIP message from the top of this PR
