### PR TITLE
add healthcheck CI script

### DIFF
--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -1,0 +1,17 @@
+name: Healthcheck
+
+on:
+  schedule:
+    - cron: "0 7 * * 1" # at 7am UTC on mondays
+
+jobs:
+  healthcheck:
+    name: Healthcheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Healthcheck for website & backend
+        uses: jtalk/url-health-check-action@v2
+        with:
+          url: https://politicry.com|https://politicry.com/api/1/register/
+          follow-redirect: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Politicry
 
 ![Test](https://github.com/se310-t6/politicry/actions/workflows/test.yml/badge.svg)
+![Healthcheck](https://github.com/se310-t6/politicry/actions/workflows/healthcheck.yml/badge.svg)
 ![Sonarcloud](https://github.com/se310-t6/politicry/actions/workflows/sonarcloud.yml/badge.svg)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=se310-t6_politicry&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=se310-t6_politicry)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=se310-t6_politicry&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=se310-t6_politicry)


### PR DESCRIPTION
## Todo

- [x] set up GitHub CI to check whether the website is still working every monday at 7am UTC
- [x] set up GitHub CI to check whether the backend is still working every monday at 7am UTC
- [x] show healthcheck results in the README
- [x] set up GitHub to email us when the healthcheck fails (automatically happens for everyone watching this repo)

## Motivation

This feature was requested in #41 

## Attached GitHub issue

Closes #41 

## Checklist

### Documentation

- [x] Updated the readme documents (`README.md` etc.)
- [x] ~~New functions and methods have additional comments added to document their usage~~

### Local Build

- [x] Ran all pre-commit hooks `pre-commit run --all-files`
- [x] Extension has been tested to build correctly `cd extension && yarn && yarn build`
- [x] Backend has been tested to build correctly `cd backend && docker-compose build`
- [x] Extension test suite has been run locally `cd extension && yarn && yarn test`
- [x] Backend test suite has been run locally `cd backend && python3 -m unittest`

### GitHub

- [x] Target branch has been set correctly
- [x] PR has been rebased onto target branch
- [x] PR has been assigned an owner
- [x] Author has performed a self-review of the code
- [x] Removed the WIP message from the top of this PR
