### PR TITLE
create a help page

### DIFF
--- a/extension/cypress/e2e/popup.cy.js
+++ b/extension/cypress/e2e/popup.cy.js
@@ -1,6 +1,8 @@
 /// <reference types="cypress" />
 
 describe("extension popup", () => {
+  let onInstalledCallback;
+
   beforeEach(() => {
     cy.visit("http://localhost:1234", {
       onBeforeLoad(window) {
@@ -23,6 +25,17 @@ describe("extension popup", () => {
         window.chrome.tabs = {
           query: async () => [{ url: "https://example.com" }],
         };
+        window.chrome.runtime = {
+          getManifest: () => ({ version: "🧪" }),
+          onInstalled: {
+            addListener(f) {
+              onInstalledCallback = f;
+            },
+          },
+          OnInstalledReason: {
+            INSTALL: "install",
+          },
+        };
 
         // override window.open so that we can assert if it's called without a new tab opening
         cy.stub(window, "open").as("openNewTab");
@@ -38,7 +51,7 @@ describe("extension popup", () => {
   });
 
   // Tooltip tests
-  
+
   it("hides tooltips by default", () => {
     cy.get(".tooltip").each(($tooltip) => {
       cy.get($tooltip).should("have.css", "visibility", "hidden");
@@ -94,5 +107,19 @@ describe("extension popup", () => {
       blockedWords: ["train", "metro", "bus"],
       currentUrl: "https://example.com",
     });
+  });
+
+  it("does not open the help page by default", () => {
+    cy.get("@openNewTab").should("not.have.been.calledWith");
+  });
+
+  it("does not open the help page by default", () => {
+    onInstalledCallback({ reason: "install" });
+    cy.get("@openNewTab").should(
+      "have.been.calledWith",
+      "https://politicry.com/help#/",
+      "_blank",
+      "noopener",
+    );
   });
 });

--- a/extension/package.json
+++ b/extension/package.json
@@ -27,5 +27,5 @@
     "test": "start-server-and-test 'parcel public/popup.html' 1234 'cypress open'",
     "build": "webpack --config webpack/webpack.config.js"
   },
-  "version": "1.0.0"
+  "version": "2.0.0"
 }

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -33,5 +33,5 @@
   "manifest_version": 3,
   "name": "Politicry",
   "permissions": ["activeTab", "scripting", "storage"],
-  "version": "1.0"
+  "version": "2.0.0"
 }

--- a/extension/public/popup.html
+++ b/extension/public/popup.html
@@ -25,9 +25,9 @@
         </a>
       </div>
       <div class="version">
-        <span>Version 1.0.0</span>
+        <span><!-- version number gets inserted here --></span>
         <a
-          href="https://github.com/se310-t6/politicry"
+          href="https://github.com/se310-t6/politicry/releases"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -56,7 +56,10 @@
             </div>
             <div class="toggle-item">
               <div class="tooltip-element">
-                <img alt="Instagram logo" src="./images/icon-instagram-128.png" />
+                <img
+                  alt="Instagram logo"
+                  src="./images/icon-instagram-128.png"
+                />
                 <span class="tooltip">Instagram</span>
               </div>
               <label class="switch">
@@ -121,12 +124,12 @@
         <span> Report an issue</span>
       </a>
       <a
-        href="https://github.com/se310-t6/politicry"
+        href="https://politicry.com/help#/"
         target="_blank"
         rel="noopener noreferrer"
         style="margin: 16px"
       >
-        <span>Full Docs</span>
+        <span>Help & Documentation</span>
         <img alt="External link icon" src="./images/external-link-128.png" />
       </a>
     </footer>

--- a/extension/public/popup.js
+++ b/extension/public/popup.js
@@ -1,6 +1,8 @@
 /// <reference types="chrome" />
 /* global chrome */
 
+const { version } = chrome.runtime.getManifest();
+
 /** ******** Enabled Sites **********/
 
 // UI references
@@ -231,10 +233,20 @@ document.querySelector("#report-link").addEventListener("click", async () => {
 
   const context = { ...settings, currentUrl: tabs[0].url };
 
-  // open the help page in a new tag, and append the data to the end of the URL
+  // open the report-issue page in a new tab, and append the data to the end of the URL
   window.open(
     `https://politicry.com/report#${btoa(JSON.stringify(context))}`,
     "_blank",
     "noopener",
   );
 });
+
+chrome.runtime.onInstalled.addListener((details) => {
+  if (details.reason == chrome.runtime.OnInstalledReason.INSTALL) {
+    // open the docs page in a new tab when the extension is first installed
+    window.open("https://politicry.com/help#/", "_blank", "noopener");
+  }
+});
+
+// update the version number in the UI based on the manifest.json file
+document.querySelector(".version > span").innerHTML = `Version ${version}`;

--- a/website/__tests__/help.test.js
+++ b/website/__tests__/help.test.js
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/vue";
+// eslint-disable-next-line import/no-unresolved
+import help from "@/pages/help.vue";
+
+describe("/report", () => {
+  it("shows the installation section by default", async () => {
+    window.__defineGetter__("location", () => ({ hash: "" }));
+
+    render(help);
+    expect(screen.queryByText("Installation")).toBeTruthy();
+  });
+
+  it("hides the installation section if the page is opened from the extension", async () => {
+    window.__defineGetter__("location", () => ({ hash: "#/" }));
+
+    render(help);
+    expect(screen.queryByText("Installation")).toBeFalsy();
+  });
+});

--- a/website/components/NavBar.vue
+++ b/website/components/NavBar.vue
@@ -25,8 +25,10 @@
 
     <div id="navBar" class="navbar-menu">
       <div class="navbar-end">
-        <a href="#about" class="navbar-item"> About </a>
-        <a href="#team" class="navbar-item"> The Team </a>
+        <a href="/#about" class="navbar-item"> About </a>
+        <a href="/#team" class="navbar-item"> The Team </a>
+        <a href="/help" class="navbar-item"> Docs </a>
+        <a href="/report" class="navbar-item"> Report Issue </a>
         <a href="https://se310-t6.github.io/politicry/" class="navbar-item">
           Api
           <b-icon icon="link" type="is-secondary" class="ml-2" />

--- a/website/package.json
+++ b/website/package.json
@@ -32,5 +32,5 @@
     "test": "vue-cli-service test:unit",
     "start": "nuxt start"
   },
-  "version": "1.0.0"
+  "version": "2.0.0"
 }

--- a/website/pages/help.vue
+++ b/website/pages/help.vue
@@ -1,0 +1,150 @@
+<template>
+  <main>
+    <h1>Getting started with Politicry</h1>
+    <p>
+      Politicry is a browser extension that blurs posts which contain certain
+      words that you can define.
+    </p>
+
+    <img
+      src="https://user-images.githubusercontent.com/16009897/194502415-26aa9f63-beae-4ea1-bfc7-097a545177a5.png"
+      alt="Screenshot of the Instagram showing a blurred post next to a normal post"
+      class="card"
+      style="max-height: 300px"
+    />
+    <p>
+      This screenshot shows a blurred post next to a normal post in Instagram.
+    </p>
+
+    <template v-if="!hideInstallSection">
+      <hr />
+      <h1>Installation</h1>
+      Politicry has not yet been published. It supports
+      <a href="https://google.com/chrome">Google Chrome</a> and
+      <a href="https://microsoft.com/edge">Microsoft Edge</a>.
+      <img
+        src="https://storage.googleapis.com/web-dev-uploads/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/HRs9MPufa1J1h5glNhut.png"
+        alt="Available in the Chrome Web Store"
+        style="height: 100px"
+      />
+    </template>
+
+    <hr />
+    <h1>Enabling the Extension</h1>
+    <p>
+      Once Installed, Politicry can be launched by clicking the
+      <code>
+        <img src="favicon.png" alt="Politicry Logo" style="height: 15px" />
+      </code>
+      icon in the URL bar. <br /><br />
+
+      Under the <code>Enabled Sites</code> header, you can choose which social
+      media platforms Politicry should check.
+    </p>
+    <img
+      src="https://user-images.githubusercontent.com/16009897/194503059-f10dc6f1-e3db-4a68-b6dd-a7b13840a5c6.png"
+      alt="Screenshot of the Politicry extension"
+      class="card"
+      style="max-height: 300px"
+    />
+    <p>
+      Enabling the switch next to the 🌐 globe icon will disable Politicry on
+      all websites.
+    </p>
+
+    <hr />
+    <h1>Configuring blocked words</h1>
+    <p>
+      Click on the tab called <code>Blocked Words</code> to configure which
+      words will cause a post to be blurred.
+    </p>
+
+    <img
+      src="https://user-images.githubusercontent.com/16009897/194503272-a2f57f43-96ac-42a1-aca6-12df2b9275f5.png"
+      alt="Screenshot of a list of blocked words"
+      class="card"
+      style="max-height: 300px"
+    />
+    <p>
+      In this example, there are 4 words configured. To edit them, click the
+      <code>Edit Blocked</code> button.
+    </p>
+
+    <img
+      src="https://user-images.githubusercontent.com/16009897/194503277-8852f6fa-e3c1-4676-bda4-c46f3bf92482.png"
+      alt="Screenshot of blocked words being configured"
+      class="card"
+      style="max-height: 300px"
+    />
+    <p>
+      When editting the list, separate words using a comma (<code>,</code>).
+      Spaces are optional.
+    </p>
+
+    <hr />
+    <h1>Configuring allowed words</h1>
+    If a post contained an <em>allowed word</em>, it will be visible to you even
+    if it contains some <em>blocked word</em>. For example, If you configure
+    <code>Sushi</code> as a banned word and <code>Avocado</code> as an allowed
+    word, then you will not see any posts about sushi except for avocado sushi.
+
+    <h1>Using the extension</h1>
+    Once you've configured the extension, politicry will blur posts on all
+    social media platforms that have been enabled.
+    <br /><br />
+    For example, configure <code>train</code> and <code>rail</code> as blocked
+    words, and then visit some of these pages:
+
+    <ul>
+      <li><a href="https://instagr.am/p/CjYuHG-PBsM">An Instagram post</a></li>
+      <li>
+        <a href="https://instagr.am/metrolosangeles">An Instagram profile</a>
+      </li>
+      <li>
+        <a href="https://twitter.com/ptv_official/status/1578190027091283968"
+          >A Twitter post</a
+        >
+      </li>
+      <li><a href="https://twitter.com/ptv_official">A Twitter feed</a></li>
+      <li><a href="https://reddit.com/r/trains">A Reddit page</a></li>
+    </ul>
+
+    <hr />
+    <h1>Troubleshooting</h1>
+    If you have any issues, feel free to
+    <a href="https://politicry.com/report">report an error</a>.
+
+    <hr />
+    <h1>Further documentation</h1>
+    If you're a software developer, you might be interested in the
+    <a href="https://se310-t6.github.io/politicry">API Documentation</a>.
+    Politicry is open source and
+    <a href="https://github.com/se310-t6/politicry">available on GitHub</a>.
+  </main>
+</template>
+
+<style>
+h1 {
+  margin-top: 32px;
+  font-size: x-large;
+  font-weight: 800;
+}
+ul {
+  list-style: disc;
+  margin-left: 20px;
+}
+main {
+  max-width: 800px;
+  margin: auto;
+  padding: 0 32px;
+}
+</style>
+<script>
+export default {
+  data: () => ({
+    // We hide the "Installation" section of the help page if the user already has the extension installed.
+    // We know if the user arrived at this page from the extension because the URL will end with #/
+    hideInstallSection: window.location.hash === "#/",
+  }),
+};
+</script>


### PR DESCRIPTION
This is a relatively simple PR. There is a new file `help.vue` which corresponds to ``https://politicry.com/help`. 

The page has two variants, depending on where the extension is installed or not. If the extension _is_ installed, we don't need to show the installation section. 

This PR updates the "help" link in the extension popup to point to the new help website. The extension will append `#/` to the end of the URL when it opens it. The website checks if the URL ends with `#/` and if so, it hides the installation section. This is the easiest way to check if the extension is installed. Alternative solutions are more complex and would further decrease the maintainability of this codebase, with very little benefit. 

## Todo

- [x] Create https://politicry.com/help
- [x] Write tests for https://politicry.com/help
- [x] Update the extension popup to open https://politicry.com/help when it's first installed
- [x]  Update the extension popup to link to the help page
- [x] Write tests for the automatic page opening 
- [x] Hide the installation section of the help page if the extension is already installed 
  - This works because the extension will always append `#/` to the help URL before opening it. The website can detect this.
- [x] _Unrelated:_ change the version number to `2.0.0` for Assignment 3 and reduce the number of places where the version number is duplicated, by loading the version number from the `manifest.json` file. 

## Motivation

The UI might be intimidating for new users since there are lots of options but no exaplanation of how anything works. 

## Attached GitHub issue

Closes #106

## Checklist

### Documentation

- [x] ~~Updated the readme documents (`README.md` etc.)~~
- [x] New functions and methods have additional comments added to document their usage

### Local Build

- [x] Ran all pre-commit hooks `pre-commit run --all-files`
- [x] Extension has been tested to build correctly `cd extension && yarn && yarn build`
- [x] Backend has been tested to build correctly `cd backend && docker-compose build`
- [x] Extension test suite has been run locally `cd extension && yarn && yarn test`
- [x] Backend test suite has been run locally `cd backend && python3 -m unittest`

### GitHub

- [x] Target branch has been set correctly
- [x] PR has been rebased onto target branch
- [x] PR has been assigned an owner
- [x] Author has performed a self-review of the code
- [x] Removed the WIP message from the top of this PR
