### PR TITLE
Make blocked tab enabled by default

### DIFF
--- a/extension/cypress/e2e/popup.cy.js
+++ b/extension/cypress/e2e/popup.cy.js
@@ -43,6 +43,15 @@ describe("extension popup", () => {
     });
   });
 
+  // Allowed/Blocked tab tests
+
+  it("enabled the blocked words tab by default", () => {
+    cy.get("#manageTagListBtn").should("have.text", "Edit Blocked");
+    // Cypress detects rgb instead of hex colours
+    cy.get("#blockedBtn").should("have.css", "background-color", "rgb(33, 150, 243)"); // #2196F3
+    cy.get("#allowedBtn").should("have.css", "background-color", "rgb(153, 153, 153)"); //#999999
+  });
+
   // Checbox tests
 
   it("enables the correct checkboxes", () => {

--- a/extension/public/popup.js
+++ b/extension/public/popup.js
@@ -217,7 +217,7 @@ manageTagListBtn.onclick = manageTagListBtnHandler;
 saveBtn.onclick = saveBtnHandler;
 cancelBtn.onclick = cancelBtnHandler;
 
-allowedBtnHandler();
+blockedBtnHandler();
 
 // send context infomation to the report page when the user clicks the report link
 document.querySelector("#report-link").addEventListener("click", async () => {


### PR DESCRIPTION
## Todo
- [x] Enable blocked words instead of allowed words when the extension is opened

## Motivation
Users are more likely to access blocked words than allowed words. 

## Summary of changes
Very simple one line change. Call the Blocked tab button handler instead of the Allowed tab button handler at the start of `popup.js`. Also added tests to verify that the blocked tab is enabled by default. 

## Attached GitHub issue
Closes #90

## Checklist

### Local Build
- [x] Extension has been tested to build correctly `cd extension && yarn && yarn build`
- [x] Extension test suite has been run locally `cd extension && yarn && yarn test`

### GitHub
- [x] Target branch has been set correctly
- [x] PR has been rebased onto target branch
- [x] PR has been assigned an owner
- [x] Author has performed a self-review of the code
- [x] Removed the WIP message from the top of this PR
