### PR TITLE
Use allowed words in detection logic

### DIFF
--- a/extension/cypress/e2e/popup.cy.js
+++ b/extension/cypress/e2e/popup.cy.js
@@ -16,6 +16,7 @@ describe("extension popup", () => {
                 redditToggled: true,
                 twitterToggled: false,
                 blockedWords: ["train", "metro", "bus"],
+                allowedWords: ["chicken"],
               };
               return cb?.(data) || new Promise((cb) => cb(data));
             },
@@ -102,7 +103,7 @@ describe("extension popup", () => {
     cy.get("a#report-link").click();
 
     const data =
-      "eyJyZWRkaXRUb2dnbGVkIjp0cnVlLCJ0d2l0dGVyVG9nZ2xlZCI6ZmFsc2UsImJsb2NrZWRXb3JkcyI6WyJ0cmFpbiIsIm1ldHJvIiwiYnVzIl0sImN1cnJlbnRVcmwiOiJodHRwczovL2V4YW1wbGUuY29tIn0=";
+      "eyJyZWRkaXRUb2dnbGVkIjp0cnVlLCJ0d2l0dGVyVG9nZ2xlZCI6ZmFsc2UsImJsb2NrZWRXb3JkcyI6WyJ0cmFpbiIsIm1ldHJvIiwiYnVzIl0sImFsbG93ZWRXb3JkcyI6WyJjaGlja2VuIl0sImN1cnJlbnRVcmwiOiJodHRwczovL2V4YW1wbGUuY29tIn0=";
     cy.get("@openNewTab").should(
       "be.calledWith",
       "https://politicry.com/report#" + data,
@@ -114,6 +115,7 @@ describe("extension popup", () => {
       redditToggled: true,
       twitterToggled: false,
       blockedWords: ["train", "metro", "bus"],
+      allowedWords: ["chicken"],
       currentUrl: "https://example.com",
     });
   });

--- a/extension/cypress/e2e/worker.cy.js
+++ b/extension/cypress/e2e/worker.cy.js
@@ -54,4 +54,16 @@ describe("extension worker", () => {
         .should("not.have.css", "filter", "blur(5px)");
     });
   });
+
+  describe("allowed", () => {
+    it("does not blur posts with allowed words", () => {
+      cy.get("#allowed div[lang='en']")
+        .first()
+        .should("not.have.css", "filter", "blur(4px)");
+
+      cy.get("#allowed div[lang='en']")
+        .last()
+        .should("not.have.css", "filter", "blur(4px)");
+    });
+  });
 });

--- a/extension/public/popup.js
+++ b/extension/public/popup.js
@@ -86,8 +86,8 @@ const renderAllowedWords = () => {
   hideTagsEdit();
 
   chrome.storage.sync.get(["allowedWords"], (data) => {
-    const allowedWordsData = data.allowedWords;
-    if (allowedWordsData === undefined || allowedWordsData.length === 0) {
+    let allowedWordsData = data.allowedWords;
+    if (allowedWordsData.length === 0) {
       tagList.innerHTML = "No keywords set!";
       return;
     }
@@ -116,9 +116,7 @@ const renderBlockedWords = () => {
   hideTagsEdit();
   chrome.storage.sync.get(["blockedWords"], (data) => {
     let blockedWordsData = data.blockedWords;
-    if (!blockedWordsData) {
-      blockedWordsData = window.defaultBlockedWordsList;
-    } else if (blockedWordsData.length === 0) {
+    if (blockedWordsData.length === 0) {
       tagList.innerHTML = "No keywords set!";
       return;
     }
@@ -151,13 +149,11 @@ const renderTagsEdit = () => {
 
   if (manageTagListBtn.innerHTML === "Edit Allowed") {
     chrome.storage.sync.get(["allowedWords"], (data) => {
-      editTagsTextArea.value = arrayToCsv(data.allowedWords || []);
+      editTagsTextArea.value = arrayToCsv(data.allowedWords);
     });
   } else {
     chrome.storage.sync.get(["blockedWords"], (data) => {
-      let list = data.blockedWords;
-      if (!list) list = window.defaultBlockedWordsList;
-      editTagsTextArea.value = arrayToCsv(list);
+      editTagsTextArea.value = arrayToCsv(data.blockedWords);
     });
   }
 };
@@ -217,7 +213,23 @@ manageTagListBtn.onclick = manageTagListBtnHandler;
 saveBtn.onclick = saveBtnHandler;
 cancelBtn.onclick = cancelBtnHandler;
 
-blockedBtnHandler();
+// set initial value of allowed/blocked list if it doesn't exist
+chrome.storage.sync.get(["allowedWords"], (data) => {
+  if (!data.allowedWords) {
+    chrome.storage.sync.set({ allowedWords: [] });
+  }
+  
+});
+
+chrome.storage.sync.get(["blockedWords"], (data) => {
+  if (!data.blockedWords) {
+    chrome.storage.sync.set({ blockedWords: window.defaultBlockedWordsList });
+  }
+
+  // blocked tab is clicked on start-up
+  // must be called after blockedWords exists (is not undefined)
+  blockedBtnHandler();  
+});
 
 // send context infomation to the report page when the user clicks the report link
 document.querySelector("#report-link").addEventListener("click", async () => {

--- a/extension/public/worker-test.html
+++ b/extension/public/worker-test.html
@@ -10,7 +10,7 @@
 <----->
 
 All Red images ("Pizza") should be blurred. <br />
-All green images ("Sushi") should NOT be blurred.
+All green images ("Sushi" and "Chicken") should NOT be blurred.
 
 <main id="instagram">
   <h1>Instagram</h1>
@@ -55,6 +55,11 @@ All green images ("Sushi") should NOT be blurred.
     <img src="https://via.placeholder.com/140x140/12e377/ffffff?text=Sushi" />
   </div>
 </main>
+<main id="allowed">
+  <h1>Posts with allowed words</h1>
+  <div lang="en">🟢 This post is about Pizza and Chicken 🟢</div>
+  <div lang="en">🟢 This post is about Chicken 🟢</div>
+</main>
 <script>
   // this file is used for testing the worker code.
   window.chrome ||= {};
@@ -62,10 +67,15 @@ All green images ("Sushi") should NOT be blurred.
   window.chrome.storage.sync ||= {};
 
   // mock the chrome user preferences
-  window.chrome.storage.sync.get = (keys, cb) =>
+  window.chrome.storage.sync.get = (_, cb) =>
     setTimeout(
-      () => cb(Object.fromEntries(keys.map((key) => [key, true]))),
-      100,
+      () => cb({ 
+        redditToggled: true,
+        instagramToggled: true,
+        twitterToggled: true,
+        blockedWords: ["pizza"], 
+        allowedWords: ["chicken"] ,
+      }), 100,
     );
 </script>
 <!-- <script src="./tesseract.min.js" defer></script> -->

--- a/extension/public/worker/shared.js
+++ b/extension/public/worker/shared.js
@@ -13,9 +13,10 @@ window.defaultBlockedWordsList = [
 ];
 
 let blockedList = window.defaultBlockedWordsList;
+let allowedList = [];
 
 chrome.storage.sync.get(
-  ["blockedWords", "redditToggled", "instagramToggled", "twitterToggled"],
+  ["blockedWords", "allowedWords", "redditToggled", "instagramToggled", "twitterToggled"],
   (data) => {
     window.enabled = {
       reddit: data.redditToggled,
@@ -23,9 +24,13 @@ chrome.storage.sync.get(
       twitter: data.twitterToggled,
     };
 
-    // replace the blocklist with the list from chrome storage
+    // replace the allowed/blocked list with the list from chrome storage
     if (data.blockedWords && data.blockedWords.length) {
       blockedList = data.blockedWords;
+    }
+
+    if (data.allowedWords && data.allowedWords.length) {
+      allowedList = data.allowedWords;
     }
 
     // lastly, emit the "politicry-ready" event, which the other files listen for
@@ -33,6 +38,10 @@ chrome.storage.sync.get(
   },
 );
 
-/* returns true if the supplied text matches any word in the blocked list */
-window.matchesBlocklist = (text) =>
-  blockedList.some((word) => text.toLowerCase().includes(word.toLowerCase()));
+/* returns true if the supplied text matches any word in the blocked list 
+unless it contains an allowed word */
+window.matchesBlocklist = (text) => {
+  let hasAllowedWord = allowedList.some((word) => text.toLowerCase().includes(word.toLowerCase()))
+  let hasBlockedWord = blockedList.some((word) => text.toLowerCase().includes(word.toLowerCase()))
+  return !hasAllowedWord && hasBlockedWord
+}


### PR DESCRIPTION
## Todo

- [x] Incorporate allowed words into detection logic 
- [x] Add test(s) to verify behaviour on posts with both allowed and blocked words

## Motivation
The allowed words list currently do nothing. See #103 for more. 

## Summary of changes
[First commit](https://github.com/se310-t6/politicry/pull/111/commits/7cb5bb07815e294f5fd7deb2a32e158869b80efd)
Refactor allowed/blocked list interactions by checking for undefined Chrome Storage values at the start of `popup.js`. If undefined, the default list of words is set. This means we do not need to make null checks in the rest of the file. As a result, `blockedBtnHandler` must be called within the getting/setting of initial allowed/blocked words to ensure that we do not encounter any undefined values. 

[Second commit](https://github.com/se310-t6/politicry/pull/111/commits/1d83919b7863694541347de608842fc1a6756529)
Incorporating the allowed word list into `window.matchesBlocklist`. This will now return false if the post contains an allowed word. As `window.matchesBlocklist` is conveniently located in `shared.js`, changes only need to be made here instead of separately for all the supported platforms. 

[Third commit](https://github.com/se310-t6/politicry/pull/111/commits/456459d00364ab1eaaf2c48a106948e6365cc47a)
Testing. Added 2 checks - (1) for when a post contains a blocked and allowed word, (2) for when a post contains an allowed word. Chrome storage mocking in `worker-test.html` needed to be updated to contain the allowed words.  
Small update in `popup.cy.js` to ensure the tests pass. 

## Attached GitHub issue
Closes #103 

## Checklist
### Documentation
- [x] New functions and methods have additional comments added to document their usage

### Local Build
- [x] Extension has been tested to build correctly `cd extension && yarn && yarn build`
- [x] Extension test suite has been run locally `cd extension && yarn && yarn test`

### GitHub
- [x] Target branch has been set correctly
- [x] PR has been rebased onto target branch
- [x] PR has been assigned an owner
- [x] Author has performed a self-review of the code
- [x] Removed the WIP message from the top of this PR
