### PR TITLE
Updated Twitter blur functionality

### DIFF
--- a/extension/cypress/e2e/worker.cy.js
+++ b/extension/cypress/e2e/worker.cy.js
@@ -35,11 +35,11 @@ describe("extension worker", () => {
     it("blurs the correct tweets", () => {
       cy.get("#twitter div[lang='en']")
         .first()
-        .should("have.css", "filter", "blur(4px)");
+        .should("have.css", "filter", "blur(20px)");
 
       cy.get("#twitter div[lang='en']")
         .last()
-        .should("not.have.css", "filter", "blur(4px)");
+        .should("not.have.css", "filter", "blur(20px)");
     });
   });
 

--- a/extension/cypress/e2e/worker.cy.js
+++ b/extension/cypress/e2e/worker.cy.js
@@ -33,11 +33,11 @@ describe("extension worker", () => {
 
   describe("twitter", () => {
     it("blurs the correct tweets", () => {
-      cy.get("#twitter article")
+      cy.get("#twitter > article")
         .first()
         .should("have.css", "filter", "blur(20px)");
 
-      cy.get("#twitter article")
+      cy.get("#twitter > article")
         .last()
         .should("not.have.css", "filter", "blur(20px)");
     });

--- a/extension/cypress/e2e/worker.cy.js
+++ b/extension/cypress/e2e/worker.cy.js
@@ -33,11 +33,11 @@ describe("extension worker", () => {
 
   describe("twitter", () => {
     it("blurs the correct tweets", () => {
-      cy.get("#twitter div[lang='en']")
+      cy.get("#twitter article")
         .first()
         .should("have.css", "filter", "blur(20px)");
 
-      cy.get("#twitter div[lang='en']")
+      cy.get("#twitter article")
         .last()
         .should("not.have.css", "filter", "blur(20px)");
     });

--- a/extension/public/worker-test.html
+++ b/extension/public/worker-test.html
@@ -36,8 +36,12 @@ All green images ("Sushi") should NOT be blurred.
 
 <main id="twitter">
   <h1>Twitter</h1>
-  <div lang="en">🔴 This tweet is about Pizza 🔴</div>
-  <div lang="en">🟢 This tweet is about Sushi 🟢</div>
+  <article>
+    <div lang="en">🔴 This tweet is about Pizza 🔴</div>
+  </article>
+  <article>
+    <div lang="en">🟢 This tweet is about Sushi 🟢</div>
+  </article>
 </main>
 
 <main id="reddit">

--- a/extension/public/worker/twitter.js
+++ b/extension/public/worker/twitter.js
@@ -11,8 +11,9 @@ document.addEventListener("politicry-ready", () => {
 
   // check every 1 second if a new post has been loaded
   setInterval(() => {
-    // check every visible tweet, which can be identified since it's a
-    // div with an attribute called lang="en". Politicry only supports English (for now)
+    // check every visible tweet, which can be identified since each tweet is a different
+    // article. Politicry currently only supports English (for now) but tweets in any language
+    // that contain any of the blocked words will be blurred.
     document.querySelectorAll('article').forEach(checkTweet);
   }, 1000);
 });

--- a/extension/public/worker/twitter.js
+++ b/extension/public/worker/twitter.js
@@ -1,7 +1,7 @@
 /** @param {HTMLDivElement} el */
 function checkTweet(el) {
   if (window.matchesBlocklist(el.innerText)) {
-    el.style.filter = "blur(4px)";
+    el.style.filter = "blur(20px)";
   }
 }
 
@@ -13,6 +13,6 @@ document.addEventListener("politicry-ready", () => {
   setInterval(() => {
     // check every visible tweet, which can be identified since it's a
     // div with an attribute called lang="en". Politicry only supports English (for now)
-    document.querySelectorAll('div[lang="en"]').forEach(checkTweet);
+    document.querySelectorAll('article').forEach(checkTweet);
   }, 1000);
 });


### PR DESCRIPTION
## Todo

- [x] Fix Twitter blur functionality by blurring all parts of the tweet
- [x] Increase blur to accommodate for video/images

## Motivation

Politicry only blurs the text for Twitter. The user is still able to see other parts of the tweet that they may not like to see such as graphic/unwanted video and images 

## Summary of changes

Changed search to search for each `'article'` rather than each `'div[lang="en"]'` in `extension\public\worker\twitter.js`

## Attached GitHub issue

Closes #97 

## Checklist

<!-- If not applicable to this PR, the item can be checked, crossed out, or removed. -->

### Documentation

- [x] New functions and methods have additional comments added to document their usage

### Local Build

- [x] Extension has been tested to build correctly `cd extension && yarn && yarn build`

### GitHub

- [x] Target branch has been set correctly
- [x] PR has been rebased onto target branch
- [x] PR has been assigned an owner
- [x] Author has performed a self-review of the code
- [x] Removed the WIP message from the top of this PR
